### PR TITLE
Login/api modify

### DIFF
--- a/src/app/home/error.tsx
+++ b/src/app/home/error.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function HomeError({
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 text-center">
+      <h1 className="text-4xl font-bold text-red-600 mb-4">오류 발생</h1>
+      <p className="text-lg text-gray-700 mb-8">
+        로그인에 실패했습니다. 관리자에게 문의하세요.
+      </p>
+      <button
+        className="text-blue-500 underline"
+        onClick={() => {
+          reset();
+          localStorage.removeItem('user');
+        }}
+      >
+        다시 시도하기
+      </button>
+      <Link className="text-blue-500 underline" href="/home">
+        홈페이지로 돌아가기
+      </Link>
+    </div>
+  );
+}

--- a/src/entities/auth/api/api.ts
+++ b/src/entities/auth/api/api.ts
@@ -1,4 +1,9 @@
-import { LoginRequest, ProviderTypes, UserDTO } from '@/features/auth';
+import {
+  type KakaoPayload,
+  type NaverPayload,
+  ProviderTypes,
+  UserDTO,
+} from '@/features/auth';
 
 export const loginUser = async ({ provider }: ProviderTypes) => {
   const isProduction = process.env.NODE_ENV === 'production';
@@ -20,7 +25,7 @@ export const loginUser = async ({ provider }: ProviderTypes) => {
 
 export const fetchUserData = async (
   provider: 'kakao' | 'naver',
-  body: LoginRequest
+  body: KakaoPayload | NaverPayload
 ): Promise<UserDTO> => {
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_SERVER_URL}auth/login/${provider}`,

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,7 +1,8 @@
 export { LoginButton } from './ui/LoginButton';
 export type {
   ProviderTypes,
-  LoginRequest,
+  KakaoPayload,
+  NaverPayload,
   UserDTO,
   UserResponseDTO,
 } from './model/types';

--- a/src/features/auth/model/hooks/useSocialLogin.ts
+++ b/src/features/auth/model/hooks/useSocialLogin.ts
@@ -3,6 +3,11 @@ import { useEffect } from 'react';
 import { fetchUserData } from '@/entities/auth';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 export const useSocialLogin = () => {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const redirectUrl = isProduction
+    ? process.env.NEXT_PUBLIC_CLIENT_URL
+    : process.env.NEXT_PUBLIC_LOCAL_HOST;
+
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -17,6 +22,7 @@ export const useSocialLogin = () => {
       if (pathname.includes('kakao')) {
         const kakaoBody = {
           code: code,
+          redirectUrl: `${redirectUrl}/auth/kakao/callback`,
         };
         fetchUserData('kakao', kakaoBody)
           .then((user) => {

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -18,7 +18,12 @@ export interface UserResponseDTO {
   data: UserDTO;
 }
 
-export interface LoginRequest {
+export interface NaverPayload {
   code: string;
-  state?: string;
+  state: string;
+}
+
+export interface KakaoPayload {
+  code: string;
+  redirectUrl: string;
 }


### PR DESCRIPTION
### 작업내용
- loginRequest 를 KakaoPayload , NaverPayload 로 분리 (백엔드와 통일)
- /home에 error.tsx를 추가. reset 하고 localStorage의 user의 value를 remove 하는 로직을 추가.
- 임시적인 error 레이아웃을 추가.

### 추가적인 작업
- 공통 Error 컴포넌트를 만들고, 각기 다른 에러에 대응할 수 있게 확장성 넓히기